### PR TITLE
Drivetrain pwm fixes

### DIFF
--- a/src/arduino_serial_package/arduino_files/drivetrain/lib/Drive_Kinematics/DD_Kinematics.h
+++ b/src/arduino_serial_package/arduino_files/drivetrain/lib/Drive_Kinematics/DD_Kinematics.h
@@ -17,23 +17,20 @@ class DD_Kinematics
         struct velocities
         {
             float linear_x;
-            float linear_y;
             float angular_z;
         };
         DD_Kinematics(int motor_max_rpm, float wheel_diameter, float fr_wheels_dist, float lr_wheels_dist, int pwm_bits);
         velocities getVelocities(int motor1, int motor2, int motor3, int motor4);
-        output getRPM(float linear_x, float linear_y, float angular_z);
-        output getPWM(float linear_x, float linear_y, float angular_z);
+        output getRPM(float linear_x, float angular_z);
+        output getPWM(float linear_x, float angular_z);
         int RPMtoPWM(int rpm);
 
     private:
         float linear_vel_x_mins_;
-        float linear_vel_y_mins_;
         float angular_vel_z_mins_;
         float circumference_;
         float tangential_vel_;
         float x_rpm_;
-        float y_rpm_;
         float tan_rpm_;
         int max_rpm_;
         float fr_wheels_dist_;

--- a/src/arduino_serial_package/arduino_files/drivetrain/src/drivetrain.cpp
+++ b/src/arduino_serial_package/arduino_files/drivetrain/src/drivetrain.cpp
@@ -95,7 +95,7 @@ void loop()
   float ang_vel_z = daTwist.angular_z;
 
   //find required rpm for each motor to obtain the desired values
-  rpm = Kinematics.getRPM(linear_vel_x, linear_vel_y, ang_vel_z);
+  rpm = Kinematics.getRPM(linear_vel_x, ang_vel_z);
 
   //Disable motor 1 if RPM is zero
   if (rpm.motor1 == 0) {
@@ -178,12 +178,12 @@ void loop()
   }
 
   // Initalize getPWM so that pwm.motor(n) will work
-  pwm = Kinematics.getPWM(linear_vel_x, linear_vel_y, ang_vel_z);
+  pwm = Kinematics.getPWM(linear_vel_x, ang_vel_z);
 
-  analogWrite(motor1_pin, abs(pwm.motor1));
-  analogWrite(motor2_pin, abs(pwm.motor2));
-  analogWrite(motor3_pin, abs(pwm.motor3));
-  analogWrite(motor4_pin, abs(pwm.motor4));
+  analogWrite(motor1_pin, pwm.motor1);
+  analogWrite(motor2_pin, pwm.motor2);
+  analogWrite(motor3_pin, pwm.motor3);
+  analogWrite(motor4_pin, pwm.motor4);
 }
 
 Twist parseTwistandReturn(const String &msg)

--- a/src/arduino_serial_package/arduino_files/drivetrain/src/drivetrain.cpp
+++ b/src/arduino_serial_package/arduino_files/drivetrain/src/drivetrain.cpp
@@ -91,7 +91,6 @@ void loop()
 
   //Hardcode velocity and angular velocity to test, in m/s and rad/s
   float linear_vel_x = daTwist.linear_x;
-  float linear_vel_y = daTwist.linear_y;
   float ang_vel_z = daTwist.angular_z;
 
   //find required rpm for each motor to obtain the desired values


### PR DESCRIPTION
Removed redundant linear y, made it so that pwm can never exceed 255, rpm can never exceed maximum set rpm, and RPMtoPWM function can only output positive PWM values.